### PR TITLE
Update dependencies, Go version, and actions versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,14 +13,13 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: 1.22
-      id: go
-    - uses: dominikh/staticcheck-action@v1.1.0
-      with:
-        version: "2023.1"
     - name: Check out code into the Go module directory
       uses: actions/checkout@v4
     - name: Lint, test and build
       run: |
+
+        # Install staticcheck for linting
+        go install honnef.co/go/tools/cmd/staticcheck@2023.1
 
         # Lint and format
         make lint

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,16 +9,16 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-    - name: Set up Go 1.17
-      uses: actions/setup-go@v1
+    - name: Set up Go 1.22
+      uses: actions/setup-go@v5
       with:
-        go-version: 1.17
+        go-version: 1.22
       id: go
     - uses: dominikh/staticcheck-action@v1.1.0
       with:
-        version: "2022.1"
+        version: "2023.1"
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v1
+      uses: actions/checkout@v4
     - name: Lint, test and build
       run: |
 
@@ -43,7 +43,7 @@ jobs:
 
     - name: Publish linux 386
       if: github.event_name == 'release'
-      uses: Shopify/upload-to-release@1.0.0
+      uses: Shopify/upload-to-release@v1
       with:
         name: simple-proxy_linux_386.zip
         path: dist/simple-proxy_linux_386.zip
@@ -51,7 +51,7 @@ jobs:
 
     - name: Publish linux amd64
       if: github.event_name == 'release'
-      uses: Shopify/upload-to-release@1.0.0
+      uses: Shopify/upload-to-release@v1
       with:
         name: simple-proxy_linux_amd64.zip
         path: dist/simple-proxy_linux_amd64.zip
@@ -59,7 +59,7 @@ jobs:
 
     - name: Publish linux arm
       if: github.event_name == 'release'
-      uses: Shopify/upload-to-release@1.0.0
+      uses: Shopify/upload-to-release@v1
       with:
         name: simple-proxy_linux_arm.zip
         path: dist/simple-proxy_linux_arm.zip
@@ -67,7 +67,7 @@ jobs:
 
     - name: Publish linux arm64
       if: github.event_name == 'release'
-      uses: Shopify/upload-to-release@1.0.0
+      uses: Shopify/upload-to-release@v1
       with:
         name: simple-proxy_linux_arm64.zip
         path: dist/simple-proxy_linux_arm64.zip
@@ -75,7 +75,7 @@ jobs:
 
     - name: Publish darwin amd64
       if: github.event_name == 'release'
-      uses: Shopify/upload-to-release@1.0.0
+      uses: Shopify/upload-to-release@v1
       with:
         name: simple-proxy_darwin_amd64.zip
         path: dist/simple-proxy_darwin_amd64.zip
@@ -83,7 +83,7 @@ jobs:
 
     - name: Publish darwin arm64
       if: github.event_name == 'release'
-      uses: Shopify/upload-to-release@1.0.0
+      uses: Shopify/upload-to-release@v1
       with:
         name: simple-proxy_darwin_arm64.zip
         path: dist/simple-proxy_darwin_arm64.zip
@@ -91,7 +91,7 @@ jobs:
 
     - name: Publish windows 386
       if: github.event_name == 'release'
-      uses: Shopify/upload-to-release@1.0.0
+      uses: Shopify/upload-to-release@v1
       with:
         name: simple-proxy_windows_386.zip
         path: dist/simple-proxy_windows_386.zip
@@ -99,7 +99,7 @@ jobs:
 
     - name: Publish windows amd64
       if: github.event_name == 'release'
-      uses: Shopify/upload-to-release@1.0.0
+      uses: Shopify/upload-to-release@v1
       with:
         name: simple-proxy_windows_amd64.zip
         path: dist/simple-proxy_windows_amd64.zip

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
 
     - name: Publish linux 386
       if: github.event_name == 'release'
-      uses: Shopify/upload-to-release@v1
+      uses: Shopify/upload-to-release@1.0.0
       with:
         name: simple-proxy_linux_386.zip
         path: dist/simple-proxy_linux_386.zip
@@ -51,7 +51,7 @@ jobs:
 
     - name: Publish linux amd64
       if: github.event_name == 'release'
-      uses: Shopify/upload-to-release@v1
+      uses: Shopify/upload-to-release@1.0.0
       with:
         name: simple-proxy_linux_amd64.zip
         path: dist/simple-proxy_linux_amd64.zip
@@ -59,7 +59,7 @@ jobs:
 
     - name: Publish linux arm
       if: github.event_name == 'release'
-      uses: Shopify/upload-to-release@v1
+      uses: Shopify/upload-to-release@1.0.0
       with:
         name: simple-proxy_linux_arm.zip
         path: dist/simple-proxy_linux_arm.zip
@@ -67,7 +67,7 @@ jobs:
 
     - name: Publish linux arm64
       if: github.event_name == 'release'
-      uses: Shopify/upload-to-release@v1
+      uses: Shopify/upload-to-release@1.0.0
       with:
         name: simple-proxy_linux_arm64.zip
         path: dist/simple-proxy_linux_arm64.zip
@@ -75,7 +75,7 @@ jobs:
 
     - name: Publish darwin amd64
       if: github.event_name == 'release'
-      uses: Shopify/upload-to-release@v1
+      uses: Shopify/upload-to-release@1.0.0
       with:
         name: simple-proxy_darwin_amd64.zip
         path: dist/simple-proxy_darwin_amd64.zip
@@ -83,7 +83,7 @@ jobs:
 
     - name: Publish darwin arm64
       if: github.event_name == 'release'
-      uses: Shopify/upload-to-release@v1
+      uses: Shopify/upload-to-release@1.0.0
       with:
         name: simple-proxy_darwin_arm64.zip
         path: dist/simple-proxy_darwin_arm64.zip
@@ -91,7 +91,7 @@ jobs:
 
     - name: Publish windows 386
       if: github.event_name == 'release'
-      uses: Shopify/upload-to-release@v1
+      uses: Shopify/upload-to-release@1.0.0
       with:
         name: simple-proxy_windows_386.zip
         path: dist/simple-proxy_windows_386.zip
@@ -99,7 +99,7 @@ jobs:
 
     - name: Publish windows amd64
       if: github.event_name == 'release'
-      uses: Shopify/upload-to-release@v1
+      uses: Shopify/upload-to-release@1.0.0
       with:
         name: simple-proxy_windows_amd64.zip
         path: dist/simple-proxy_windows_amd64.zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 ### Added
 - New `--bind` option which allows you to specify what address to bind to, defaults to `0.0.0.0`.
+### Changed
+- Updated to Go version `1.22`.
 
 ## [v1.1.1] - 2023-12-04
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,7 +134,7 @@ the other projects that solved it better and which could serve as inspiration.
 
 Developing this project requires these dependencies:
 
-* [Go](https://golang.org/doc/install) >= `1.21`
+* [Go](https://golang.org/doc/install) >= `1.22`
 * [Static Check](https://github.com/dominikh/go-tools) == `2023.1 (v0.4.0)`
 
 ### Commands

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,8 +134,8 @@ the other projects that solved it better and which could serve as inspiration.
 
 Developing this project requires these dependencies:
 
-* [Go](https://golang.org/doc/install) >= `1.17`
-* [Static Check](https://github.com/dominikh/go-tools) == `2022.1 (v0.3.0)`
+* [Go](https://golang.org/doc/install) >= `1.21`
+* [Static Check](https://github.com/dominikh/go-tools) == `2023.1 (v0.4.0)`
 
 ### Commands
 

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/jthomperoo/simple-proxy
 
-go 1.17
+go 1.22
 
 require github.com/golang/glog v1.0.0


### PR DESCRIPTION
- Go v1.22
- Staticcheck 2023.1 (v0.4.0)
- GitHub actions updated to latest versions