### PR TITLE
Add a new feature to tunnel HTTP requests to a Socks5 Proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,14 @@ anywhere and run.
 
 Code based on the guide here: <https://medium.com/@mlowicki/http-s-proxy-in-golang-in-less-than-100-lines-of-code-6a51c2f2c38c>
 
+
+## HTTP转Socks5
+由于最新docer免费版无法在容器内连外部socks5代理，https://docs.docker.com/desktop/networking/#socks5-proxy-support  
+因此在容器外部开这个代理：  
+```
+./dist/linux_arm64/simple-proxy -port 7990
+```
+
 ## Features
 
 - HTTP and HTTPS.

--- a/README.md
+++ b/README.md
@@ -5,14 +5,6 @@ anywhere and run.
 
 Code based on the guide here: <https://medium.com/@mlowicki/http-s-proxy-in-golang-in-less-than-100-lines-of-code-6a51c2f2c38c>
 
-
-## HTTP转Socks5
-由于最新docer免费版无法在容器内连外部socks5代理，https://docs.docker.com/desktop/networking/#socks5-proxy-support  
-因此在容器外部开这个代理：  
-```
-./dist/linux_arm64/simple-proxy -port 7990
-```
-
 ## Features
 
 - HTTP and HTTPS.
@@ -26,6 +18,7 @@ Code based on the guide here: <https://medium.com/@mlowicki/http-s-proxy-in-gola
 - Can log request headers.
 - Can log failed authentication attempt details.
 - Printing version number.
+- Tunnel HTTP proxy to socks5 proxy
 
 ## Install
 
@@ -56,6 +49,10 @@ You can run the binary directly:
 
 ```bash
 ./simple-proxy
+
+# tunnel the http proxy to socks5 proxy
+# client -> localhost:7990 [http proxy] -> 127.0.0.1:7890 [socks5 proxy] -> server
+./simple-proxy -port 7990 -socks 127.0.0.1:7890
 ```
 
 ## Windows
@@ -94,6 +91,8 @@ Usage of simple-proxy:
     	log to standard error instead of files
   -port string
     	proxy port to listen on (default "8888")
+  -socks5 string
+    	proxy tunnel the http requests to a socks5 proxy (default "", feature off)
   -protocol string
     	proxy protocol (http or https) (default "http")
   -stderrthreshold value

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/jthomperoo/simple-proxy
 
 go 1.22
 
-require github.com/golang/glog v1.0.0
+require (
+	github.com/golang/glog v1.0.0
+	golang.org/x/net v0.30.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/golang/glog v1.0.0 h1:nfP3RFugxnNRyKgeWd4oI1nYvXpxrx8ck8ZrcizshdQ=
 github.com/golang/glog v1.0.0/go.mod h1:EWib/APOK0SL3dFbYqvxE3UYd8E6s1ouQ7iEp/0LWV4=
+golang.org/x/net v0.30.0 h1:AcW1SDZMkb8IpzCdQUaIq2sP4sZ4zw+55h6ynffypl4=
+golang.org/x/net v0.30.0/go.mod h1:2wGyMJ5iFasEhkwi13ChkO/t1ECNC4X4eBKkVFyYFlU=

--- a/main.go
+++ b/main.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/golang/glog"
-	"github.com/jthomperoo/simple-proxy/my_proxy"
+	my_proxy "github.com/jthomperoo/simple-proxy/proxy"
 )
 
 var (
@@ -37,7 +37,7 @@ func main() {
 	var port string
 	flag.StringVar(&port, "port", "8888", "proxy port to listen on")
 	var socks5 string
-	flag.StringVar(&socks5, "socks5", "127.0.0.1:7890", "SOCKS5 proxy to use for tunneling")
+	flag.StringVar(&socks5, "socks5", "", "SOCKS5 proxy for tunneling")
 	var certPath string
 	flag.StringVar(&certPath, "cert", "", "path to cert file")
 	var keyPath string
@@ -97,6 +97,9 @@ func main() {
 
 	if protocol == httpProtocol {
 		glog.V(0).Infoln("Starting HTTP proxy...")
+		if socks5 != "" {
+			glog.V(0).Infof("Tunneling HTTP requests to SOCKS5 proxy: %s\n", socks5)
+		}
 		log.Fatal(server.ListenAndServe())
 	} else {
 		glog.V(0).Infoln("Starting HTTPS proxy...")

--- a/main.go
+++ b/main.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/golang/glog"
-	"github.com/jthomperoo/simple-proxy/proxy"
+	"github.com/jthomperoo/simple-proxy/my_proxy"
 )
 
 var (
@@ -36,6 +36,8 @@ func main() {
 	flag.StringVar(&bind, "bind", "0.0.0.0", "address to bind the proxy server to")
 	var port string
 	flag.StringVar(&port, "port", "8888", "proxy port to listen on")
+	var socks5 string
+	flag.StringVar(&socks5, "socks5", "127.0.0.1:7890", "SOCKS5 proxy to use for tunneling")
 	var certPath string
 	flag.StringVar(&certPath, "cert", "", "path to cert file")
 	var keyPath string
@@ -63,9 +65,11 @@ func main() {
 		glog.Fatalf("If using HTTPS protocol --cert and --key are required\n")
 	}
 
+	my_proxy.Socks5 = socks5
+
 	var handler http.Handler
 	if basicAuth == "" {
-		handler = &proxy.ProxyHandler{
+		handler = &my_proxy.ProxyHandler{
 			Timeout:    time.Duration(timeoutSecs) * time.Second,
 			LogAuth:    logAuth,
 			LogHeaders: logHeaders,
@@ -75,7 +79,7 @@ func main() {
 		if len(parts) < 2 {
 			glog.Fatalf("Invalid basic auth provided, must be in format 'username:password', auth: %s\n", basicAuth)
 		}
-		handler = &proxy.ProxyHandler{
+		handler = &my_proxy.ProxyHandler{
 			Timeout:    time.Duration(timeoutSecs) * time.Second,
 			Username:   &parts[0],
 			Password:   &parts[1],

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -13,7 +13,7 @@ import (
 )
 
 // Using a socks5 proxy to tunnel the HTTP requests, e.g., 127.0.0.1:7890
-var Socks5 = "" 
+var Socks5 = ""
 
 func NewProxyHandler(timeoutSeconds int) *ProxyHandler {
 	return &ProxyHandler{

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -8,11 +8,12 @@ import (
 	"strings"
 	"time"
 
-	net_proxy "golang.org/x/net/proxy"
 	"github.com/golang/glog"
+	net_proxy "golang.org/x/net/proxy"
 )
 
-var Socks5 = "127.0.0.1:7890"
+// Using a socks5 proxy to tunnel the HTTP requests, e.g., 127.0.0.1:7890
+var Socks5 = "" 
 
 func NewProxyHandler(timeoutSeconds int) *ProxyHandler {
 	return &ProxyHandler{


### PR DESCRIPTION
Hi, I am a Docker user and want to use a SOCKS5 proxy inside a container. However, the latest version of Docker Desktop has moved SOCKS5 proxy support to the [Business subscription](https://docs.docker.com/desktop/networking/#socks5-proxy-support).

Previously, we could set up a SOCKS proxy (e.g., listening on 0.0.0.0:7890) on the host and configure environment variables inside the container to enable the proxy:
```
# set_proxy.sh inside the container
proxy=172.17.0.1:7890 # host SOCKS5 proxy
export https_proxy=http://${proxy} http_proxy=http://${proxy}
git config --global http.proxy http://${proxy}
git config --global https.proxy http://${proxy}
```

However, this approach no longer works, and we found that the container cannot access the SOCKS5 proxy at 172.17.0.1:7890. Interestingly, if we change the SOCKS5 proxy to an HTTP proxy (e.g., simple_proxy), everything works as expected.

To address this issue, I added a new feature to simple_proxy that allows it to tunnel HTTP requests to the SOCKS proxy. This enables us to use a SOCKS5 proxy inside the container.

```
# On the host
# Step 1: Start a SOCKS5 proxy at 0.0.0.0:7890
# Step 2: Start simple_proxy
$ ./simple_proxy -port 7990 -socks5 127.0.0.1:7890

# Inside the container
$ export https_proxy=http://172.17.0.1:7990 http_proxy=http://172.17.0.1:7990
$ curl xxx.com
```

With this setup, the traffic inside the container is handled by the HTTP proxy and tunneled to the SOCKS5 proxy.
> curl -> 172.17.0.1:7990 (simple_proxy, http request) -> simple_proxy, tunnel -> 172.17.0.1:7890 (host socks5 proxy)